### PR TITLE
Curie -> Skłodowska-Curie

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ humandate: "COMPLETAR"    # fechas del taller en formato legible (por ejemplo, "
 humantime: "COMPLETAR"    # hora del taller en formato legible (por ejemplo, "9:00 am - 4:30 pm")
 startdate: COMPLETAR      # fecha de inicio del taller en formato YYYY-MM-DD (por ejemplo, 2015-01-01)
 enddate: COMPLETAR        # fecha de finalización del taller en formato YYYY-MM-DD, por ejemplo 2015-01-02
-instructor: ["COMPLETAR"] # lista de nombres de las instructoras separados por comas y entre corchetes, como ["Hedy Lamarr", "Ada Lovelace", "Madame Curie"]
+instructor: ["COMPLETAR"] # lista de nombres de las instructoras separados por comas y entre corchetes, como ["Hedy Lamarr", "Ada Lovelace", "Marie Skłodowska-Curie"]
 helper: ["COMPLETAR"]     # lista de nombres de las **helpers** separados por comas y entre corchetes, como ["Carrie Fisher", "Frances Allen", "Margaret Hamilton"]
 email: ["fixme@example.org"]    # lista de direcciones de correo electrónico de contacto con la **host** ó **lead instructor**, separadas por comas y entre corchetes, como ["ada.lovelace@ejemplo.org", "carrie.fisher@ejemplo.org", "hedy.lamarr@example.org"]
 collaborative_notes:             # optional: URL de las notas colaborativas del taller, por ejemplo un Etherpad o documento de Google Docs 


### PR DESCRIPTION
It would be great to comply with now common practice of acknowledging Marie Curie's Polish origins indicating both her surnames as she did herself:

- Here's her double-surname signature:
   https://en.wikipedia.org/wiki/Marie_Curie#/media/File:Marie_Curie_Sk%C5%82odowska_Signature_Polish.svg 
- Here's her Nobel prize diploma with both surnames:
   https://en.wikipedia.org/wiki/File:Marie_Sk%C5%82odowska-Curie%27s_Nobel_Prize_in_Chemistry_1911.jpg

Quoting the European Commission website comment regarding the renaming of the "Marie Curie Actions" into "Marie Skłodowska-Curie Actions" (https://ec.europa.eu/research-and-innovation/en/horizon-magazine/marie-sklodowska-curie-actions-supporting-europes-best-and-brightest-researchers-25-years):  "the programme was renamed the Marie Skłodowska-Curie Actions (MSCA), emphasising the namesake’s Polish heritage and diversity."
