### PR TITLE
Update slack links

### DIFF
--- a/bin/boilerplate/README.md
+++ b/bin/boilerplate/README.md
@@ -1,6 +1,6 @@
 # FIXME Lesson title
 
-[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://swc-slack-invite.herokuapp.com/)
+[![Create a Slack Account with us](https://img.shields.io/badge/Create_Slack_Account-The_Carpentries-071159.svg)](https://slack-invite.carpentries.org/)
 
 FIXME
 


### PR DESCRIPTION
Update slack links to point to the new domain URL and invite app.